### PR TITLE
Derive `Clone` for `StlParams` and `StlResults`

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -1,7 +1,7 @@
 use crate::Error;
 use crate::stl::stl;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StlParams {
     ns: Option<usize>,
     nt: Option<usize>,
@@ -17,7 +17,7 @@ pub struct StlParams {
     robust: bool
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StlResult {
     seasonal: Vec<f32>,
     trend: Vec<f32>,


### PR DESCRIPTION
This makes the structs more convenient to use, following the [C-COMMON-TRAITS API guideline][guidelines].

I've based this on v0.2.2 in case you wanted to make a patch release, but can rebase it on main if you're planning on bump the minor version anyway 🙂 

[guidelines]: https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits