### PR TITLE
Make `StlResults` fields public

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -19,10 +19,10 @@ pub struct StlParams {
 
 #[derive(Debug)]
 pub struct StlResult {
-    seasonal: Vec<f32>,
-    trend: Vec<f32>,
-    remainder: Vec<f32>,
-    weights: Vec<f32>
+    pub seasonal: Vec<f32>,
+    pub trend: Vec<f32>,
+    pub remainder: Vec<f32>,
+    pub weights: Vec<f32>
 }
 
 pub fn params() -> StlParams {


### PR DESCRIPTION
It's currently hard to store the results of the STL decomposition without using `to_vec()` on the various slices returned by the seasonal/trend/remainder/weights accessor methods, which unfortunately requires cloning all the data. By making the fields public the caller can decide what to do with them.

An alternative could be to add some sort of `into_parts()` method which returns all four as a tuple or something, but this just seemed easier!